### PR TITLE
Removed port logic from DQD

### DIFF
--- a/DataQualityDashboard/www/index.html
+++ b/DataQualityDashboard/www/index.html
@@ -141,8 +141,7 @@
   <script type="text/javascript" src="https://cdn.datatables.net/buttons/1.5.6/js/buttons.html5.min.js"></script>
 
   <script type="text/javascript">
-    // if not running in shiny, try to accomodate web server
-    if (location.port == 80 || location.port == 8080 || location.port == "") {
+    
       $.ajax({
         dataType: "json",
         url: "results.json",
@@ -150,7 +149,6 @@
           loadResults(results);
         }
       });
-    }
 
   </script>
 


### PR DESCRIPTION
Per @leeevans , this port logic is causing websockets issue. Removing as we don't need the web server option here, it is a shiny app only